### PR TITLE
Fix duplicate quad faces in OBJ export for triangulated quads

### DIFF
--- a/src/TT_QuadFaceTools/entities.rb
+++ b/src/TT_QuadFaceTools/entities.rb
@@ -1726,9 +1726,7 @@ module TT::Plugins::QuadFaceTools
         quad
       elsif QuadFace.is?( entity )
         quad = QuadFace.new( entity )
-        if add_to_cache && @types[ Sketchup::Face ][ entity ].nil?
-          cache_entity( quad )
-        end
+        cache_entity( quad ) if add_to_cache
         quad
       else
         entity


### PR DESCRIPTION
When exporting to OBJ, any quad face represented as two triangles (triangulated quad) was being exported as **two separate quad polygons** instead of one. This caused geometry duplication in the exported file.

You can find the issue here: https://github.com/thomthom/quadface-tools/issues/134. I thinks it's also the root cause of these other issues: https://github.com/thomthom/quadface-tools/issues/127, https://github.com/thomthom/quadface-tools/issues/124, https://github.com/thomthom/quadface-tools/issues/120

In `EntitiesProvider#get_entity`, when a triangulated quad's native faces had been previously cached as plain `Sketchup::Face` objects (which happens during `EntitiesProvider.new`), the condition guarding `cache_entity` prevented the created `QuadFace` from being stored in `@faces_to_quads`:

```ruby
if add_to_cache && @types[ Sketchup::Face ][ entity ].nil?
  cache_entity( quad )
end
```

During OBJ export, `write_entities` calls `Surface.get(native_entities, true)`, which groups the two triangles of a quad into a single `Surface` (they share a soft edge). Then `entities.get(surface.faces)` is called on `[triangle1, triangle2]`.

Because neither triangle was in `@faces_to_quads` yet, two **separate** `QuadFace` instances were created for the same underlying triangles. Since `QuadFace` has no `==` method, `.uniq` could not deduplicate them, and both were written to the OBJ file.

Remove the guard condition so that `cache_entity` is always called when `add_to_cache` is `true`:

```ruby
cache_entity( quad ) if add_to_cache
```

After caching the `QuadFace` created from `triangle1`, both `triangle1` and `triangle2` are registered in `@faces_to_quads`. When `triangle2` is subsequently processed, it returns the **same** `QuadFace` instance, so `.uniq` correctly collapses the list to a single quad.
